### PR TITLE
feat: Allow configuring patch server port at build time

### DIFF
--- a/.github/workflows/cp_dispatch.yml
+++ b/.github/workflows/cp_dispatch.yml
@@ -14,10 +14,15 @@ on:
         options:
           - Windows (x86_64)
           - Linux (x86_64)
+      patch-server-port:
+        description: 'Patch server port (useful for resolving port conflicts)"'
+        required: true
+        default: '5678'
 
 env:
   OS_ARCH: ${{ github.event.inputs.os-and-arch }}
   VERSION_TO_PATCH: ${{ github.event.inputs.version_to_patch }}
+  PATCH_SERVER_PORT: ${{ github.event.inputs.patch-server-port }}
 
 jobs:
 
@@ -461,6 +466,19 @@ jobs:
             Write-Host "Source Server Folder not found"
           }
         shell: pwsh
+
+      - name: Set patch server port (in main.js of server)
+        run: |
+          $source_index = "msojocs-patch/server/index.js"
+          $index_content = Get-Content -Path $source_index -Raw
+
+          if (Test-Path $source_index) {
+            $index_content = $index_content -replace 'const port = \d+;', "const port = $env:PATCH_SERVER_PORT;"
+            Set-Content -Path $source_index -Value $index_content
+            Write-Host "Server port set to $env:PATCH_SERVER_PORT"
+          } else {
+            Write-Host "index.js (from server) not found"
+          }
 
       - name: Patch main.js to main.original.js
         run: |

--- a/.github/workflows/cp_latest_dispatch.yml
+++ b/.github/workflows/cp_latest_dispatch.yml
@@ -11,6 +11,10 @@ on:
         options:
           - Windows (x86_64)
           - Linux (x86_64)
+      patch-server-port:
+        description: 'Patch server port (useful for resolving port conflicts)"'
+        required: true
+        default: '5678'
 
 env:
   OS_ARCH: ${{ github.event.inputs.os-and-arch }}
@@ -438,6 +442,19 @@ jobs:
             Write-Host "Source Server Folder not found"
           }
         shell: pwsh
+
+      - name: Set patch server port (in main.js of server)
+        run: |
+          $source_index = "msojocs-patch/server/index.js"
+          $index_content = Get-Content -Path $source_index -Raw
+
+          if (Test-Path $source_index) {
+            $index_content = $index_content -replace 'const port = \d+;', "const port = $env:PATCH_SERVER_PORT;"
+            Set-Content -Path $source_index -Value $index_content
+            Write-Host "Server port set to $env:PATCH_SERVER_PORT"
+          } else {
+            Write-Host "index.js (from server) not found"
+          }
 
       - name: Patch main.js to main.original.js
         run: |

--- a/.github/workflows/cp_latest_dispatch.yml
+++ b/.github/workflows/cp_latest_dispatch.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   OS_ARCH: ${{ github.event.inputs.os-and-arch }}
+  PATCH_SERVER_PORT: ${{ github.event.inputs.patch-server-port }}
 
 jobs:
 


### PR DESCRIPTION
Users may occasionally encounter port conflicts, which previously required manually editing resources/app/out/main.js.
This update allows specifying the desired port at build time, providing a cleaner and more user-friendly solution.