### PR TITLE
fix: correct the wrong description of last name from `first` to `last`

### DIFF
--- a/.github/workflows/cp_dispatch.yml
+++ b/.github/workflows/cp_dispatch.yml
@@ -27,7 +27,7 @@ on:
         required: true
         default: 'Long'
       patch-user-lastName:
-        description: 'Fake registered first name (for fake FE account)'
+        description: 'Fake registered last name (for fake FE account)'
         required: true
         default: 'Wang'
       patch-user-country-code:

--- a/.github/workflows/cp_latest_dispatch.yml
+++ b/.github/workflows/cp_latest_dispatch.yml
@@ -24,7 +24,7 @@ on:
         required: true
         default: 'Long'
       patch-user-lastName:
-        description: 'Fake registered first name (for fake FE account)'
+        description: 'Fake registered last name (for fake FE account)'
         required: true
         default: 'Wang'
       patch-user-country-code:


### PR DESCRIPTION
The description of the workflow config is wrong. The second `first name` is actually `last name`.

previous:
![](https://github.com/user-attachments/assets/5b1ce376-09f2-467c-bd2e-2de29048850c)

now:
![](https://github.com/user-attachments/assets/11cdd428-db56-48c5-9a04-70a6fbfc6849)
