### PR TITLE
chore: update actions version

### DIFF
--- a/.github/workflows/cp_dispatch.yml
+++ b/.github/workflows/cp_dispatch.yml
@@ -61,7 +61,7 @@ jobs:
       is_valid: ${{ steps.get_validity.outputs.is_valid }}
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Validate Fiddler Version
         id: get_validity
@@ -200,7 +200,7 @@ jobs:
           }
       
       - name: Upload Yui folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Yui-patch
           path: Yui/
@@ -232,7 +232,7 @@ jobs:
         run: Get-ChildItem -Path msojocs\server
 
       - name: Upload msojocs folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: msojocs-patch
           path: msojocs/
@@ -270,7 +270,7 @@ jobs:
         run: 7z x "fe_extracted/`$PLUGINSDIR/app-64.7z" -ofe_app
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -310,7 +310,7 @@ jobs:
         run: mv squashfs-root fe_app
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -363,7 +363,7 @@ jobs:
         run: Get-ChildItem -Recurse
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -386,19 +386,19 @@ jobs:
       
     steps:
       - name: Download Yukuhana-Patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: Yui-patch
           path: Yui-patch
 
       - name: Download msojocs-Server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: msojocs-patch
           path: msojocs-patch
 
       - name: Download FE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fe_app
           path: fe_app
@@ -511,7 +511,7 @@ jobs:
           }
 
       - name: Upload Artifact for Patched FE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "${{ steps.rename-fe.outputs.patched-fe-name }}"
           path: "${{ steps.rename-fe.outputs.patched-fe-name }}/"

--- a/.github/workflows/cp_latest_dispatch.yml
+++ b/.github/workflows/cp_latest_dispatch.yml
@@ -102,7 +102,7 @@ jobs:
       scraped_version: ${{ steps.get_version.outputs.scraped_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run the Powershell script
         id: get_version
@@ -195,7 +195,7 @@ jobs:
           }
       
       - name: Upload Yui folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Yui-patch
           path: Yui/
@@ -225,7 +225,7 @@ jobs:
         run: Get-ChildItem -Path msojocs\server
 
       - name: Upload msojocs folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: msojocs-patch
           path: msojocs/
@@ -263,7 +263,7 @@ jobs:
         run: 7z x "fe_extracted/`$PLUGINSDIR/app-64.7z" -ofe_app
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -303,7 +303,7 @@ jobs:
         run: mv squashfs-root fe_app
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -356,7 +356,7 @@ jobs:
         run: Get-ChildItem -Recurse
         
       - name: Upload Fiddler Everywhere Extracted folder as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fe_app
           path: fe_app/
@@ -382,19 +382,19 @@ jobs:
       
     steps:
       - name: Download Yukuhana-Patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: Yui-patch
           path: Yui-patch
 
       - name: Download msojocs-Server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: msojocs-patch
           path: msojocs-patch
 
       - name: Download FE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fe_app
           path: fe_app
@@ -507,7 +507,7 @@ jobs:
           }
 
       - name: Upload Artifact for Patched FE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "${{ steps.rename-fe.outputs.patched-fe-name }}"
           path: "${{ steps.rename-fe.outputs.patched-fe-name }}/"


### PR DESCRIPTION
**Resolve the following warnings**

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

