### PR TITLE
Replace blocked issues-helper action in upstream sync workflow

### DIFF
--- a/.github/workflows/cp_pull_upstream.yml
+++ b/.github/workflows/cp_pull_upstream.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.repository.fork }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Clean issue notice
         env:

--- a/.github/workflows/cp_pull_upstream.yml
+++ b/.github/workflows/cp_pull_upstream.yml
@@ -20,10 +20,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clean issue notice
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issues'
-          labels: '🚨 Sync Fail'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "🚨 Sync Fail" \
+            --json number \
+            --jq '.[].number' |
+          while read -r issue_number; do
+            if [ -n "$issue_number" ]; then
+              gh issue close "$issue_number" \
+                --repo "${{ github.repository }}" \
+                --comment "Upstream sync is running again; closing stale failure notice."
+            fi
+          done
 
       - name: Sync upstream changes
         id: sync
@@ -37,14 +51,22 @@ jobs:
 
       - name: Sync check
         if: failure()
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-issue'
-          title: '🚨 Sync Fail | 同步失败'
-          labels: '🚨 Sync Fail'
-          body: |
-            Due to a change in the workflow file of the upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork. 
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
 
-            由于上游仓库的工作流文件发生了更改，GitHub 已自动暂停了计划的自动更新。您需要手动同步您的分叉仓库。
+          body="$(mktemp)"
+          cat > "$body" <<'EOF'
+          Due to a change in the workflow file of the upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork.
 
-            ![](https://github-production-user-asset-6210df.s3.amazonaws.com/17870709/273954625-df80c890-0822-4ac2-95e6-c990785cbed5.png)
+          由于上游仓库的工作流文件发生了更改，GitHub 已自动暂停了计划的自动更新。您需要手动同步您的分叉仓库。
+
+          ![](https://github-production-user-asset-6210df.s3.amazonaws.com/17870709/273954625-df80c890-0822-4ac2-95e6-c990785cbed5.png)
+          EOF
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "🚨 Sync Fail | 同步失败" \
+            --label "🚨 Sync Fail" \
+            --body-file "$body"


### PR DESCRIPTION
This replaces `actions-cool/issues-helper@v3` with GitHub CLI commands while keeping the upstream sync logic unchanged.

`actions-cool/issues-helper` is currently blocked by GitHub with `Repository access blocked`, causing scheduled sync runs to fail before the actual upstream sync step starts. 

Screenshot of api at 2026-05-19 03:45:00 UTC+1:
[https://api.github.com/repos/actions-cool/issues-helper](https://api.github.com/repos/actions-cool/issues-helper)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4ad56dc2-9139-4b39-ac61-fa0ce8953296" />


Changes:

- Replace the stale sync-fail issue cleanup with `gh issue list` and `gh issue close`
- Replace failure issue creation with `gh issue create`
- Keep `aormsby/Fork-Sync-With-Upstream-action@v3.4`
- Preserve the existing schedule, branch sync settings, issue title, label, and body